### PR TITLE
Add process method to plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,3 +11,9 @@ module.exports = postcss.plugin('PLUGIN_NAME', function (opts) {
 
     };
 });
+
+module.exports.process = function (css, opts) {
+    var processed = postcss([module.exports(opts)]).process(css, opts);
+
+    return opts && opts.map && !opts.map.inline ? processed : processed.css;
+};


### PR DESCRIPTION
A common convention adopted by plugin authors who also contribute to PostCSS has been to add a `process` method to their plugins, as a helper function to assist in their use standalone.

```css
require('cssnano').process(CSS_STRING, OPTIONS); // returns processed string of css 
```