### PR TITLE
Remove «KEYWORD» typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "postcss",
     "css",
-    "postcss-plugin"KEYWORDS
+    "postcss-plugin"
   ],
   "author": "AUTHOR_NAME <AUTHOR_EMAIL>",
   "license": "MIT",


### PR DESCRIPTION
Fixes a [typo in package.json](https://github.com/postcss/postcss-plugin-boilerplate/blob/master/package.json#L8)