### PR TITLE
Replace deprecated function same() by deepEqual()

### DIFF
--- a/test.js
+++ b/test.js
@@ -6,8 +6,8 @@ import plugin from './';
 function run(t, input, output, opts = { }) {
     return postcss([ plugin(opts) ]).process(input)
         .then( result => {
-            t.same(result.css, output);
-            t.same(result.warnings().length, 0);
+            t.deepEqual(result.css, output);
+            t.deepEqual(result.warnings().length, 0);
         });
 }
 


### PR DESCRIPTION
Ava prints a warning: 
`DEPRECATION NOTICE: same() has been renamed to deepEqual() and will eventually be removed. See https://github.com/jamestalmage/ava-codemods to help upgrade your codebase automatically.`