### PR TITLE
Declare number of expected warnings as fifth test parameter

### DIFF
--- a/test.js
+++ b/test.js
@@ -3,11 +3,11 @@ import test    from 'ava';
 
 import plugin from './';
 
-function run(t, input, output, opts = { }) {
+function run(t, input, output, opts = { }, warnings = 0) {
     return postcss([ plugin(opts) ]).process(input)
         .then( result => {
             t.deepEqual(result.css, output);
-            t.deepEqual(result.warnings().length, 0);
+            t.deepEqual(result.warnings().length, warnings);
         });
 }
 


### PR DESCRIPTION
Updating a project of mine, I run into the need of testing the number of expected warnings casted by my plugin.

I updated the boilerplate to accept a fifth test parameter to set the expected number of warning produced by a specific test. By default its 0.

Might be a little overhelming, anyway if you find it useful, the pull request is here ready to be merged!

Cheers!