### PR TITLE
use fs.unlink instead of rm -rf for cleanRepo function

### DIFF
--- a/start
+++ b/start
@@ -87,7 +87,22 @@ function cleanRepo(dir, callback) {
     fs.unlinkSync(readme);
     fs.renameSync(readme + '.example', readme);
     fs.unlinkSync(path.join(dir, 'start'));
-    exec('cd "' + dir + '" && rm -Rf .git/', callback);
+    deleteFolderRecursive(path.join(dir, '.git'));
+    callback();
+}
+
+function deleteFolderRecursive(path){
+    if (fs.existsSync(path)) {
+        fs.readdirSync(path).forEach(function(file,index){
+            var curPath = path + '/' + file;
+            if(fs.lstatSync(curPath).isDirectory()){
+                deleteFolderRecursive(curPath);
+            } else {
+                fs.unlinkSync(curPath);
+            }
+        });
+        fs.rmdirSync(path);
+    }
 }
 
 function initProject(dir, callback) {


### PR DESCRIPTION
resolves #43 

Use `fs.unlinkSync()` and `fs.rmdirSync()` to delete `.git` and clean the git history of the newly created repo.

Previously the git history was cleaned by executing `rm -rf .git` but this only works on unix systems.