### PR TITLE
Bug fix - ensure rmdirSync is called on dir not path module

### DIFF
--- a/start
+++ b/start
@@ -101,7 +101,7 @@ function deleteFolderRecursive(dir) {
                 fs.unlinkSync(current);
             }
         });
-        fs.rmdirSync(path);
+        fs.rmdirSync(dir);
     }
 }
 


### PR DESCRIPTION
Issue: https://github.com/postcss/postcss-plugin-boilerplate/issues/46